### PR TITLE
Add admin and message API tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,8 @@
-require('@testing-library/jest-dom'); 
+require('@testing-library/jest-dom');
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(() => ({ data: null, status: 'unauthenticated' })),
+  signIn: jest.fn(),
+  signOut: jest.fn(),
+  SessionProvider: ({ children }) => children,
+}));

--- a/src/app/api/admin/users/route.test.ts
+++ b/src/app/api/admin/users/route.test.ts
@@ -1,0 +1,46 @@
+/** @jest-environment node */
+import { GET } from './route';
+import { getServerSession } from 'next-auth';
+import { prisma } from '../../../../lib/prisma';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('../../../../lib/auth', () => ({ authOptions: {} }));
+
+jest.mock('../../../../lib/prisma', () => ({
+  prisma: {
+    user: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockFindMany = (prisma.user.findMany as unknown) as jest.Mock;
+
+describe('GET /api/admin/users', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 for non-admin user', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { role: 'STUDENT' } });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns user list for admin', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', id: '1' } });
+    const users = [{ id: '1' }, { id: '2' }];
+    mockFindMany.mockResolvedValue(users);
+
+    const res = await GET();
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockFindMany).toHaveBeenCalled();
+    expect(data).toEqual(users);
+  });
+});

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.role !== 'ADMIN') {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const users = await prisma.user.findMany({
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return NextResponse.json(users);
+}

--- a/src/app/api/messages/route.test.ts
+++ b/src/app/api/messages/route.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+import { GET, POST } from './route';
+import { getServerSession } from 'next-auth';
+import { prisma } from '../../../lib/prisma';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('../../../lib/auth', () => ({ authOptions: {} }));
+
+jest.mock('../../../lib/prisma', () => ({
+  prisma: {
+    message: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockFindMany = (prisma.message.findMany as unknown) as jest.Mock;
+const mockCreate = (prisma.message.create as unknown) as jest.Mock;
+
+describe('Messages API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects unauthenticated access', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns messages in chronological order', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: '1' } });
+    const messages = [
+      { id: '1', createdAt: '2020-01-01T00:00:00.000Z', content: 'a' },
+      { id: '2', createdAt: '2020-01-02T00:00:00.000Z', content: 'b' },
+    ];
+    mockFindMany.mockResolvedValue(messages);
+    const res = await GET();
+    const data = await res.json();
+    expect(mockFindMany).toHaveBeenCalledWith({ orderBy: { createdAt: 'asc' } });
+    expect(data).toEqual(messages);
+  });
+
+  it('creates a new message', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: '1' } });
+    const body = { content: 'hello' };
+    const req = { json: jest.fn().mockResolvedValue(body) } as any;
+    const created = { id: '3', content: 'hello', createdAt: '2025-07-25T14:00:10.595Z' };
+    mockCreate.mockResolvedValue(created);
+    const res = await POST(req);
+    const data = await res.json();
+    expect(res.status).toBe(201);
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: { content: 'hello', senderId: '1' },
+    });
+    expect(data).toEqual(created);
+  });
+});

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const messages = await prisma.message.findMany({
+    orderBy: { createdAt: 'asc' },
+  });
+
+  return NextResponse.json(messages);
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const body = await request.json();
+  const { content } = body;
+
+  const message = await prisma.message.create({
+    data: {
+      content,
+      senderId: session.user.id,
+    },
+  });
+
+  return NextResponse.json(message, { status: 201 });
+}

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,4 +1,8 @@
-import { authOptions } from './auth';
+jest.mock('@auth/prisma-adapter', () => ({
+  PrismaAdapter: jest.fn(() => ({})),
+}));
+
+const { authOptions } = require('./auth');
 
 describe('authOptions', () => {
   it('should be defined', () => {


### PR DESCRIPTION
## Summary
- add API endpoints for admin users and messages
- test admin-only behavior and message CRUD
- mock getServerSession in tests
- mock next-auth hooks globally in jest setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68838c470f10832db7f82dea6661b561