### PR TITLE
Add API auth tests

### DIFF
--- a/src/app/api/admin/users/route.test.ts
+++ b/src/app/api/admin/users/route.test.ts
@@ -25,6 +25,12 @@ describe('GET /api/admin/users', () => {
     jest.clearAllMocks();
   });
 
+  it('returns 401 for unauthenticated user', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
   it('returns 401 for non-admin user', async () => {
     mockGetServerSession.mockResolvedValue({ user: { role: 'STUDENT' } });
     const res = await GET();

--- a/src/app/api/messages/route.test.ts
+++ b/src/app/api/messages/route.test.ts
@@ -33,6 +33,13 @@ describe('Messages API', () => {
     expect(res.status).toBe(401);
   });
 
+  it('rejects unauthenticated message creation', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const req = { json: jest.fn().mockResolvedValue({ content: 'hi' }) } as any;
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
   it('returns messages in chronological order', async () => {
     mockGetServerSession.mockResolvedValue({ user: { id: '1' } });
     const messages = [


### PR DESCRIPTION
## Summary
- expand admin user API tests for unauthenticated requests
- cover message creation without a session

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883954c6670832d9a6003d09dbee354