### PR TITLE
Address roadmap issues 2-5

### DIFF
--- a/src/app/api/bookings/route.test.ts
+++ b/src/app/api/bookings/route.test.ts
@@ -1,5 +1,41 @@
-describe('API Route: /api/bookings', () => {
-  it('should be defined', () => {
-    expect(true).toBe(true);
+/** @jest-environment node */
+import { GET } from './route';
+import { getServerSession } from 'next-auth';
+import { prisma } from '../../../lib/prisma';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('../../../lib/auth', () => ({ authOptions: {} }));
+
+jest.mock('../../../lib/prisma', () => ({
+  prisma: {
+    booking: { findMany: jest.fn() },
+  },
+}));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockFindMany = (prisma.booking.findMany as unknown) as jest.Mock;
+
+describe('Bookings API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
-}); 
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET(new Request('http://localhost/api/bookings'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns bookings for authenticated student', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: '1', role: 'STUDENT' } });
+    const bookings = [{ id: 'b1' }, { id: 'b2' }];
+    mockFindMany.mockResolvedValue(bookings);
+    const res = await GET(new Request('http://localhost/api/bookings'));
+    const data = await res.json();
+    expect(mockFindMany).toHaveBeenCalled();
+    expect(data).toEqual(bookings);
+  });
+});

--- a/src/app/api/courses/route.test.ts
+++ b/src/app/api/courses/route.test.ts
@@ -1,5 +1,41 @@
-describe('API Route: /api/courses', () => {
-  it('should be defined', () => {
-    expect(true).toBe(true);
+/** @jest-environment node */
+import { GET } from './route';
+import { getServerSession } from 'next-auth';
+import { prisma } from '../../../lib/prisma';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('../../../lib/auth', () => ({ authOptions: {} }));
+
+jest.mock('../../../lib/prisma', () => ({
+  prisma: {
+    course: { findMany: jest.fn() },
+  },
+}));
+
+const mockGetServerSession = getServerSession as jest.Mock;
+const mockFindMany = (prisma.course.findMany as unknown) as jest.Mock;
+
+describe('Courses API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
-}); 
+
+  it('requires authentication', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns courses for teacher', async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: '1', role: 'TEACHER' } });
+    const courses = [{ id: 'c1' }];
+    mockFindMany.mockResolvedValue(courses);
+    const res = await GET();
+    const data = await res.json();
+    expect(mockFindMany).toHaveBeenCalled();
+    expect(data).toEqual(courses);
+  });
+});

--- a/src/app/api/messages/route.test.ts
+++ b/src/app/api/messages/route.test.ts
@@ -29,14 +29,17 @@ describe('Messages API', () => {
 
   it('rejects unauthenticated access', async () => {
     mockGetServerSession.mockResolvedValue(null);
-    const res = await GET();
+    const req = new Request('http://localhost/api/messages?recipientId=2');
+    const res = await GET(req as any);
     expect(res.status).toBe(401);
   });
 
   it('rejects unauthenticated message creation', async () => {
     mockGetServerSession.mockResolvedValue(null);
-    const req = { json: jest.fn().mockResolvedValue({ content: 'hi' }) } as any;
-    const res = await POST(req);
+    const req = {
+      json: jest.fn().mockResolvedValue({ recipientId: '2', content: 'hi' }),
+    } as any;
+    const res = await POST(req as any);
     expect(res.status).toBe(401);
   });
 
@@ -47,23 +50,37 @@ describe('Messages API', () => {
       { id: '2', createdAt: '2020-01-02T00:00:00.000Z', content: 'b' },
     ];
     mockFindMany.mockResolvedValue(messages);
-    const res = await GET();
+    const req = new Request('http://localhost/api/messages?recipientId=2');
+    const res = await GET(req as any);
     const data = await res.json();
-    expect(mockFindMany).toHaveBeenCalledWith({ orderBy: { createdAt: 'asc' } });
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { senderId: '1', recipientId: '2' },
+          { senderId: '2', recipientId: '1' },
+        ],
+      },
+      orderBy: { createdAt: 'asc' },
+    });
     expect(data).toEqual(messages);
   });
 
   it('creates a new message', async () => {
     mockGetServerSession.mockResolvedValue({ user: { id: '1' } });
-    const body = { content: 'hello' };
+    const body = { recipientId: '2', content: 'hello' };
     const req = { json: jest.fn().mockResolvedValue(body) } as any;
-    const created = { id: '3', content: 'hello', createdAt: '2025-07-25T14:00:10.595Z' };
+    const created = {
+      id: '3',
+      content: 'hello',
+      recipientId: '2',
+      createdAt: '2025-07-25T14:00:10.595Z',
+    };
     mockCreate.mockResolvedValue(created);
-    const res = await POST(req);
+    const res = await POST(req as any);
     const data = await res.json();
     expect(res.status).toBe(201);
     expect(mockCreate).toHaveBeenCalledWith({
-      data: { content: 'hello', senderId: '1' },
+      data: { content: 'hello', recipientId: '2', senderId: '1' },
     });
     expect(data).toEqual(created);
   });

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -3,13 +3,28 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
 
+  const { searchParams } = new URL(request.url);
+  const recipientId = searchParams.get('recipientId');
+  if (!recipientId) {
+    return NextResponse.json(
+      { error: 'recipientId query param required' },
+      { status: 400 }
+    );
+  }
+
   const messages = await prisma.message.findMany({
+    where: {
+      OR: [
+        { senderId: session.user.id, recipientId },
+        { senderId: recipientId, recipientId: session.user.id },
+      ],
+    },
     orderBy: { createdAt: 'asc' },
   });
 
@@ -23,11 +38,18 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json();
-  const { content } = body;
+  const { recipientId, content } = body;
+  if (!recipientId || !content) {
+    return NextResponse.json(
+      { error: 'recipientId and content are required' },
+      { status: 400 }
+    );
+  }
 
   const message = await prisma.message.create({
     data: {
       content,
+      recipientId,
       senderId: session.user.id,
     },
   });

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -291,13 +291,18 @@ export default function CalendarPage() {
                   </>
                 ) : (
                   <>
-                    <Link
-                      href="/teacher/lessons"
-                      className="block w-full text-center bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
-                    >
-                      Manage Lessons
-                    </Link>
-                    {/* Bookings page for teachers coming soon */}
+                  <Link
+                    href="/teacher/lessons"
+                    className="block w-full text-center bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
+                  >
+                    Manage Lessons
+                  </Link>
+                  <Link
+                    href="/teacher/bookings"
+                    className="block w-full text-center bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors"
+                  >
+                    View Bookings
+                  </Link>
                   </>
                 )}
               </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -113,10 +113,11 @@ export default function Dashboard() {
 
         {/* Analytics Section */}
         <div className="mb-8">
-          <Analytics 
-            bookings={bookings} 
+          <Analytics
+            bookings={bookings}
             lessons={lessons}
             userRole={session.user.role as 'TEACHER' | 'STUDENT'}
+            userId={session.user.id}
           />
         </div>
 

--- a/src/components/Analytics.test.tsx
+++ b/src/components/Analytics.test.tsx
@@ -2,10 +2,14 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import Analytics from './Analytics';
 
+global.fetch = jest.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+) as jest.Mock;
+
 describe('Analytics', () => {
   it('renders without crashing', () => {
     render(
-      <Analytics bookings={[]} lessons={[]} userRole="TEACHER" />
+      <Analytics bookings={[]} lessons={[]} userRole="TEACHER" userId="1" />
     );
     expect(screen.getByText('Total Bookings')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add recipient filtering to messages API
- enable teacher bookings link on calendar
- fetch average rating in Analytics component
- pass userId to Analytics from dashboard
- improve tests for messages, bookings, courses APIs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68839e79c4e0832dab9fb6c099079b6e