### PR TITLE
Implement notifications page

### DIFF
--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface Notification {
+  id: string;
+  type: string;
+  message: string;
+  link?: string | null;
+  read: boolean;
+  createdAt: string;
+}
+
+export default function NotificationsPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [fetchingMore, setFetchingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  useEffect(() => {
+    if (status === "loading") return;
+    if (!session) {
+      router.push("/auth/signin");
+      return;
+    }
+    fetchNotifications();
+  }, [session, status, router]);
+
+  const fetchNotifications = async (loadMore = false) => {
+    if (loadMore) setFetchingMore(true);
+    try {
+      const url = cursor && loadMore
+        ? `/api/notifications?limit=20&cursor=${cursor}`
+        : "/api/notifications?limit=20";
+      const res = await fetch(url);
+      if (!res.ok) throw new Error("Failed to fetch notifications");
+      const data: Notification[] = await res.json();
+      setNotifications(prev => loadMore ? [...prev, ...data] : data);
+      if (data.length < 20) setHasMore(false);
+      const last = data[data.length - 1];
+      if (last) setCursor(last.id);
+    } catch (err) {
+      setError("Failed to load notifications");
+      console.error("Error fetching notifications:", err);
+    } finally {
+      setLoading(false);
+      if (loadMore) setFetchingMore(false);
+    }
+  };
+
+  const markAsRead = async (id: string) => {
+    await fetch(`/api/notifications/${id}`, { method: "PATCH" });
+    setNotifications(prev => prev.map(n => n.id === id ? { ...n, read: true } : n));
+  };
+
+  if (status === "loading" || loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>Loading notifications...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center flex-col gap-4">
+        <p className="text-red-600">{error}</p>
+        <Button onClick={() => { setError(""); setLoading(true); fetchNotifications(); }}>Try Again</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">Notifications</h1>
+        {notifications.length === 0 ? (
+          <p className="text-gray-600">No notifications</p>
+        ) : (
+          <div className="space-y-4">
+            {notifications.map((notif) => (
+              <div
+                key={notif.id}
+                className={`p-4 rounded border ${notif.read ? 'bg-white' : 'bg-blue-50'}`}
+              >
+                <div className="flex justify-between items-start">
+                  <div>
+                    <p className={`font-medium ${notif.read ? 'text-gray-600' : 'text-gray-900'}`}>{notif.message}</p>
+                    <p className="text-xs text-gray-500 mt-1">{new Date(notif.createdAt).toLocaleString()}</p>
+                  </div>
+                  {!notif.read && (
+                    <Button size="sm" variant="outline" onClick={() => markAsRead(notif.id)}>Mark as read</Button>
+                  )}
+                </div>
+                {notif.link && (
+                  <Link href={notif.link} className="text-blue-600 underline text-sm block mt-2">View</Link>
+                )}
+              </div>
+            ))}
+            {hasMore && (
+              <div className="text-center">
+                <Button disabled={fetchingMore} onClick={() => fetchNotifications(true)}>
+                  {fetchingMore ? 'Loading...' : 'Load More'}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/students/bookings/create/page.tsx
+++ b/src/app/students/bookings/create/page.tsx
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic";
 
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -40,7 +40,6 @@ interface Lesson {
 export default function CreateBookingPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [isLoading, setIsLoading] = useState(false);
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [selectedLesson, setSelectedLesson] = useState<Lesson | null>(null);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -145,16 +145,27 @@ export default function Header() {
                   <div className="px-4 py-4 text-gray-500">Loading...</div>
                 ) : notifications.length === 0 ? (
                   <div className="px-4 py-4 text-gray-500">No notifications</div>
-                ) : notifications.map((notif: any) => (
-                  <button
-                    key={notif.id}
-                    onClick={() => handleNotifItemClick(notif.id, notif.link)}
-                    className={`block w-full text-left px-4 py-3 text-sm ${notif.read ? 'text-gray-500' : 'text-gray-900 font-medium bg-blue-50'} hover:bg-blue-100`}
-                  >
-                    {notif.message}
-                    <span className="block text-xs text-gray-400 mt-1">{new Date(notif.createdAt).toLocaleString()}</span>
-                  </button>
-                ))}
+                ) : (
+                  <>
+                    {notifications.map((notif: any) => (
+                      <button
+                        key={notif.id}
+                        onClick={() => handleNotifItemClick(notif.id, notif.link)}
+                        className={`block w-full text-left px-4 py-3 text-sm ${notif.read ? 'text-gray-500' : 'text-gray-900 font-medium bg-blue-50'} hover:bg-blue-100`}
+                      >
+                        {notif.message}
+                        <span className="block text-xs text-gray-400 mt-1">{new Date(notif.createdAt).toLocaleString()}</span>
+                      </button>
+                    ))}
+                    <Link
+                      href="/notifications"
+                      className="block text-center text-sm text-blue-600 py-2 border-t hover:bg-blue-50"
+                      onClick={() => setIsNotifOpen(false)}
+                    >
+                      View all
+                    </Link>
+                  </>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add a dedicated `/notifications` page
- add a link in the header dropdown to view all notifications

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68874d42f1f4832d85e695d41d0dc4eb